### PR TITLE
[Fix] 환경변수 관련 memory leak 해결

### DIFF
--- a/src/builtins/export.c
+++ b/src/builtins/export.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   export.c                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: wonyocho <wonyocho@student.42.fr>          +#+  +:+       +#+        */
+/*   By: chaoh <chaoh@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/09 18:27:13 by chaoh             #+#    #+#             */
-/*   Updated: 2024/08/27 19:13:01 by wonyocho         ###   ########.fr       */
+/*   Updated: 2024/08/28 14:01:44 by chaoh            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -61,8 +61,8 @@ t_env	*add_env(char **split_input)
 		new_env->value = ft_strdup(split_input[1]);
 		temp = ft_strjoin(new_env->key, "=");
 		new_env->data = ft_strjoin(temp, new_env->value);
+		free(temp);	
 	}
-	free(temp);
 	return (new_env);
 }
 
@@ -83,10 +83,7 @@ void	export_main(t_list **env_list, char *input)
 	new_node = ft_lstnew(new_env);
 	if (!new_node)
 	{
-		free(new_env->data);
-		free(new_env->key);
-		free(new_env->value);
-		free(new_env);
+		free_env(new_env);
 		split_free(split_input);
 		return ;
 	}
@@ -121,7 +118,6 @@ void	export(t_cmd_list *list, t_list *env_list, char **envp)
 {
 	t_list	*export_list;
 
-	export_list = copy_env_list(env_list);
 	if (list->pid == 0)
 		init_envp_list(&export_list, envp);
 	else
@@ -131,5 +127,6 @@ void	export(t_cmd_list *list, t_list *env_list, char **envp)
 		print_export_list(list, export_list);
 	else
 		argv_export(list, &env_list);
-	ft_lstclear(&export_list, free_env);
+	free_env_list(export_list);
+	g_status_code = 0;
 }

--- a/src/builtins/export_utils.c
+++ b/src/builtins/export_utils.c
@@ -6,7 +6,7 @@
 /*   By: chaoh <chaoh@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/10 16:23:54 by chaoh             #+#    #+#             */
-/*   Updated: 2024/08/25 19:57:04 by chaoh            ###   ########.fr       */
+/*   Updated: 2024/08/28 13:57:34 by chaoh            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -58,10 +58,7 @@ t_env	*copy_env(t_env *env)
 	new_env->value = ft_strdup(env->value);
 	if (!new_env->data || !new_env->key || !new_env->value)
 	{
-		free(new_env->data);
-		free(new_env->key);
-		free(new_env->value);
-		free(new_env);
+		free_env(new_env);
 		return (NULL);
 	}
 	return (new_env);
@@ -80,10 +77,17 @@ t_list	*copy_env_list(t_list *env_list)
 	{
 		new_env = copy_env((t_env *)current->content);
 		if (new_env == NULL)
+		{
+			free_env_list(new_list);
 			return (NULL);
+		}
 		new_node = ft_lstnew(new_env);
 		if (new_node == NULL)
+		{
+			free_env(new_env);
+			free_env_list(new_list);
 			return (NULL);
+		}
 		ft_lstadd_back(&new_list, new_node);
 		current = current->next;
 	}

--- a/src/builtins/unset.c
+++ b/src/builtins/unset.c
@@ -6,7 +6,7 @@
 /*   By: chaoh <chaoh@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/13 21:32:07 by chaerin           #+#    #+#             */
-/*   Updated: 2024/08/26 17:08:24 by chaoh            ###   ########.fr       */
+/*   Updated: 2024/08/28 14:11:04 by chaoh            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -29,9 +29,7 @@ void	remove_env_var(t_list **env_list, char *key)
 				*env_list = current->next;
 			else
 				previous->next = current->next;
-			free(env->key);
-			free(env->value);
-			free(env);
+			free_env(env);
 			free(current);
 			break ;
 		}

--- a/src/main.c
+++ b/src/main.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   main.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: wonyocho <wonyocho@student.42.fr>          +#+  +:+       +#+        */
+/*   By: chaoh <chaoh@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/07/30 19:15:06 by wonyocho          #+#    #+#             */
-/*   Updated: 2024/08/28 13:27:29 by wonyocho         ###   ########.fr       */
+/*   Updated: 2024/08/28 13:44:20 by chaoh            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -71,7 +71,7 @@ static void	minishell(char **envp)
 		free_cmd_list(minishell.cmd_list);
 	}
 	free_env_list(minishell.env_list);
-	// system("leaks minishell");
+	system("leaks minishell");
 }
 
 int	main(int argc, char **argv, char **envp)


### PR DESCRIPTION
**환경변수 관련 memory leak 해결**
- export로 환경변수를 등록한 상황에서 unset을 한 후 메모리 해제가 제대로 안되는 문제 발생
- unset에서 환경변수 노드를 제대로 free 해주지 않았음
- free_env 함수를 통해 free 해주는 방식으로 변경